### PR TITLE
Disable Code::TidyAll::Plugin::Test::Vars on 5.8

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ use strict;      # satisfy linter
 use warnings;    # satisfy linter
 
 requires 'Code::TidyAll::Plugin::SortLines::Naturally';
-requires 'Code::TidyAll::Plugin::Test::Vars';
+requires 'Code::TidyAll::Plugin::Test::Vars' if "$]" >= 5.010;
 requires 'Code::TidyAll::Plugin::UniqueLines';
 requires 'Devel::Cover';
 requires 'Devel::Cover::Report::Codecov';
@@ -11,7 +11,7 @@ requires 'File::Temp';
 requires 'List::MoreUtils';
 requires 'Module::Build';
 requires 'Pod::Coverage::TrustPod';
-requires 'Pod::Readme';
+requires 'Pod::Readme' if "$]" >= 5.010001;
 requires 'Test2::Bundle::Extended';
 requires 'Test2::Plugin::NoWarnings';
 requires 'Test2::Suite';
@@ -33,6 +33,6 @@ requires 'Test::Portability::Files';
 requires 'Test::RequiresInternet';
 requires 'Test::Spelling';
 requires 'Test::Synopsis';
-requires 'Test::Vars' if $] >= "5.10";
+requires 'Test::Vars' if "$]" >= 5.010;
 requires 'Test::Version';
 requires 'Test::Warnings';


### PR DESCRIPTION
Images for 5.8 are still failing...
no way we can install Code::TidyAll::Plugin::Test::Vars